### PR TITLE
Add CI workflow to build TriExporter solution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+---
+name: Build
+
+"on":
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: microsoft/setup-msbuild@v1
+        with:
+          vs-version: '17.0'
+      - name: Build solution
+        run: msbuild TriExporter.sln /p:Configuration=Release
+        # No tests currently present; add test invocation when tests exist.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Repository Agent Instructions
+
+- Run `yamllint .github/workflows/*.yml` after modifying any workflow files.
+- Ensure code builds with MSBuild or Visual Studio; the CI workflow uses `.github/workflows/build.yml` as reference.
+- No automated tests currently exist; add and run tests when available.
+- Prefer modern C++ features (RAII, smart pointers) and plan for Windows 11 UI updates (e.g., WinUI 3).
+- Keep commits focused and reference relevant tickets or issues in commit messages.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build TriExporter.sln with MSBuild on windows-latest runners
- document repository guidelines for future contributors in AGENTS.md
- clarify absence of automated tests in workflow with placeholder comment

## Testing
- `yamllint .github/workflows/build.yml`


------
https://chatgpt.com/codex/tasks/task_e_6895ad27c298832e9ad89eef955ce381